### PR TITLE
Bump Android SDK version to v1.5.1.2

### DIFF
--- a/plugin/platforms/android/include.gradle
+++ b/plugin/platforms/android/include.gradle
@@ -11,5 +11,5 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.zendesk', name: 'sdk', version: '1.5.1.1'
+    compile group: 'com.zendesk', name: 'sdk', version: '1.5.1.2'
 }


### PR DESCRIPTION
### Changes
- 1.5.1.2 fixes some ProGuard related issues

@sitefinitysteve 
