### PR TITLE
lock the pod to  '1.6.2.1'

### DIFF
--- a/plugin/platforms/ios/Podfile
+++ b/plugin/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'ZendeskSDK'
+pod 'ZendeskSDK', '1.6.2.1'


### PR DESCRIPTION
1.6.2.1 was the end of the method names as we knew them. Lock the reference or nothing will work
